### PR TITLE
Update coho to use incubator-cordova-docs ./bin/generate

### DIFF
--- a/coho
+++ b/coho
@@ -108,7 +108,7 @@ queueCommand("cd " + tempRepoDir + "/"+badadir+" && cp -r ./* " + badaReleaseBin
 
 //docs
 queueCommand("cd " + tempRepoDir + " && git clone "+docs+" && cd "+docsdir+" && git fetch --tags && git checkout "+VERSION);
-queueCommand("cd " + tempRepoDir + "/"+docsdir+" && ./bin/phonegap-docs && cp -r public/en/"+VERSION+" " + releaseDocDir);
+queueCommand("cd " + tempRepoDir + "/"+docsdir+" && ./bin/generate && cp -r public/en/"+VERSION+" " + releaseDocDir);
 
 //symbian
 fs.writeFile('depreciate.txt', 'PhoneGap-Symbian is being depreciated. You can find the last available code at https://github.com/callback/callback-symbian.', function (err) {


### PR DESCRIPTION
While refactoring cordova-docs to support the cordova namespace, I [renamed the command to generate docs](https://git-wip-us.apache.org/repos/asf?p=incubator-cordova-docs.git;a=commit;h=17b0b2c128ed77a7f40db878bb4a5496beb0cd72) from `./bin/phonegap-docs` to `./bin/generate`.

This pull request updates coho to use `./bin/generate`.
